### PR TITLE
Added updatemytalks_as private handler and sub ajax_stateful_handler

### DIFF
--- a/lib/Act/Dispatcher.pm
+++ b/lib/Act/Dispatcher.pm
@@ -69,6 +69,7 @@ my %private_handlers = (
     tracks          => 'Act::Handler::Track::List',
     updatemytalks   => 'Act::Handler::User::UpdateMyTalks',
     updatemytalks_a => 'Act::Handler::User::UpdateMyTalks::ajax_handler',
+    updatemytalks_as => 'Act::Handler::User::UpdateMyTalks::ajax_stateful_handler',
     unregister      => 'Act::Handler::User::Unregister',
     wikiedit        => 'Act::Handler::WikiEdit',
 );

--- a/lib/Act/Handler/User/UpdateMyTalks.pm
+++ b/lib/Act/Handler/User/UpdateMyTalks.pm
@@ -47,6 +47,27 @@ sub ajax_handler
     $Request{status} = HTTP_NO_CONTENT;
 }
 
+# same as ajax_handler but not toggle: accept 'state' direct parameter
+sub ajax_stateful_handler
+{
+    if( $Request{user}->has_registered && $Request{args}{talk_id} ) {
+
+        my $talk = Act::Talk->new(
+            talk_id => $Request{args}{talk_id},
+            conf_id => $Request{conference} );
+
+        my $my_talks = $Request{user}->my_talks;
+
+        $Request{user}->update_my_talks(
+            # pre-remove selected talk, if it exists:
+            grep({ $_->talk_id != $talk->talk_id } @$my_talks),
+            # and add it back, or don't add, depending from 'state' argument:
+            ($Request{args}{state} ? $talk : ()) );
+    }
+
+    $Request{status} = HTTP_NO_CONTENT;
+}
+
 1;
 
 =head1 NAME

--- a/lib/Act/User.pm
+++ b/lib/Act/User.pm
@@ -127,7 +127,7 @@ sub register_participation {
         LIMIT 1
   });
                                 
-  $sth->execute( $Request{user}->user_id );
+  $sth->execute( $self->user_id );
   my ($tshirt_size) = $sth->fetchrow_array;
   $sth->finish;
                                 

--- a/lib/Act/User.pm
+++ b/lib/Act/User.pm
@@ -115,7 +115,34 @@ sub talks {
     my ($self, %args) = @_;
     return Act::Talk->get_talks( %args, user_id => $self->user_id );
 }
-
+sub register_participation {
+  my ( $self ) = @_;
+  
+  my $sth = $Request{dbh}->prepare_cached(q{
+        SELECT  tshirt_size
+        FROM    participations
+        WHERE   user_id = ?
+        AND tshirt_size is not null
+        ORDER BY datetime DESC
+        LIMIT 1
+  });
+                                
+  $sth->execute( $Request{user}->user_id );
+  my ($tshirt_size) = $sth->fetchrow_array;
+  $sth->finish;
+                                
+  # create a new participation to this conference
+  $sth = $Request{dbh}->prepare_cached(q{
+        INSERT INTO participations
+          (user_id, conf_id, datetime, ip, tshirt_size)
+        VALUES  (?,?, NOW(), ?, ?)
+  });
+  
+  $sth->execute( $self->user_id, $Request{conference},
+    $Request{r}->connection->remote_ip, $tshirt_size );
+  $sth->finish();
+  $Request{dbh}->commit;
+}
 sub participation {
     my ( $self ) = @_;
     my $sth = sql('SELECT * FROM participations p WHERE p.user_id=? AND p.conf_id=?',

--- a/templates/js/mytalks.js
+++ b/templates/js/mytalks.js
@@ -31,7 +31,7 @@ if (window.act) {
     $(function() {
         $(".mytalks_submit").remove();
         $(":checkbox").each(function() {
-            toggle_image(this, $(this).val(), $(this).attr("checked"));
+            toggle_image(this, $(this).val(), $(this).prop("checked"));
         });
     });
 }


### PR DESCRIPTION
Added 'updatemytalks_as' for ajax_stateful_handler to specifically set or clean user's
favorite task, not to toggle.

On some pages of YAPC::EU::2015 there is few 'favorite' buttons for same task,
and when they both off and visitor presses them one-by-one, they both become
toggled to 'on' state, but two in a row request to old updatemytalks_a handler
toggles task in favorites from off to on and back to off.

So we need separate handler:
- updatemytalks_a -> toggles by 'task_id' in request.
- updatemytalks_as -> sets 'task_id' favorite state depending from additional 'state' parameter

For latter one we already provide preparations in javascript already, there:
https://github.com/Act-Conferences/ye2015/blob/master/wwwdocs/js/main.js#L22-L26
